### PR TITLE
GH-3: Make HTTP Source SI-based, add ConfigProps

### DIFF
--- a/http-app-dependencies/pom.xml
+++ b/http-app-dependencies/pom.xml
@@ -1,93 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>org.springframework.cloud.stream.app</groupId>
-    <artifactId>http-app-dependencies</artifactId>
-    <version>1.2.0.BUILD-SNAPSHOT</version>
-    <packaging>pom</packaging>
-    <name>http-app-dependencies</name>
-    <description>Spring Cloud Stream HTTP App Dependencies</description>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.springframework.cloud.stream.app</groupId>
+	<artifactId>http-app-dependencies</artifactId>
+	<version>1.2.0.BUILD-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<name>http-app-dependencies</name>
+	<description>Spring Cloud Stream HTTP App Dependencies</description>
 
-    <parent>
-	<artifactId>spring-cloud-dependencies-parent</artifactId>
-        <groupId>org.springframework.cloud</groupId>
-        <version>1.2.1.RELEASE</version>
-        <relativePath />
-    </parent>
+	<parent>
+		<artifactId>spring-cloud-dependencies-parent</artifactId>
+		<groupId>org.springframework.cloud</groupId>
+		<version>1.2.1.RELEASE</version>
+		<relativePath/>
+	</parent>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.cloud.stream.app</groupId>
-                <artifactId>spring-cloud-starter-stream-source-http</artifactId>
-                <version>1.2.0.BUILD-SNAPSHOT</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-<profiles>
-		<profile>
-			<id>spring</id>
-			<repositories>
-				<repository>
-					<id>spring-snapshots</id>
-					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/libs-snapshot-local</url>
-					<snapshots>
-						<enabled>true</enabled>
-					</snapshots>
-				</repository>
-				<repository>
-					<id>spring-milestones</id>
-					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/libs-milestone-local</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</repository>
-				<repository>
-					<id>spring-releases</id>
-					<name>Spring Releases</name>
-					<url>http://repo.spring.io/release</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</repository>
-				<repository>
-					<id>spring-libs-release</id>
-					<name>Spring Libs Release</name>
-					<url>http://repo.spring.io/libs-release</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</repository>
-				<repository>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-					<id>spring-milestone-release</id>
-					<name>Spring Milestone Release</name>
-					<url>http://repo.spring.io/libs-milestone</url>
-				</repository>
-			</repositories>
-			<pluginRepositories>
-				<pluginRepository>
-					<id>spring-snapshots</id>
-					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/libs-snapshot-local</url>
-					<snapshots>
-						<enabled>true</enabled>
-					</snapshots>
-				</pluginRepository>
-				<pluginRepository>
-					<id>spring-milestones</id>
-					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/libs-milestone-local</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</pluginRepository>
-			</pluginRepositories>
-		</profile>
-	</profiles>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud.stream.app</groupId>
+				<artifactId>spring-cloud-starter-stream-source-http</artifactId>
+				<version>1.2.0.BUILD-SNAPSHOT</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>http-app-starters-build</artifactId>
 	<version>1.2.0.BUILD-SNAPSHOT</version>
@@ -16,7 +17,20 @@
 		<module>spring-cloud-starter-stream-source-http</module>
 		<module>http-app-dependencies</module>
 	</modules>
-<profiles>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud.stream.app</groupId>
+				<artifactId>http-app-dependencies</artifactId>
+				<version>1.2.0.BUILD-SNAPSHOT</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<profiles>
 		<profile>
 			<id>spring</id>
 			<repositories>

--- a/spring-cloud-starter-stream-source-http/README.adoc
+++ b/spring-cloud-starter-stream-source-http/README.adoc
@@ -1,7 +1,7 @@
 //tag::ref-doc[]
 = Http Source
 
-A source module that listens for HTTP requests and emits the body as a message payload.
+A source application that listens for HTTP requests and emits the body as a message payload.
 If the Content-Type matches `text/*` or `application/json`, the payload will be a String,
 otherwise the payload will be a byte array.
 
@@ -10,8 +10,7 @@ otherwise the payload will be a byte array.
 The **$$http$$** $$source$$ supports the following configuration properties:
 
 //tag::configuration-properties[]
-$$http.path-pattern$$:: $$An Ant-Style pattern to determine which http requests will be captured.$$ *($$String$$, default: `$$/$$`)*
-$$server.port$$:: $$Server HTTP port.$$ *($$Integer$$, default: `$$<none>$$`)*
+
 //end::configuration-properties[]
 
 //end::ref-doc[]

--- a/spring-cloud-starter-stream-source-http/pom.xml
+++ b/spring-cloud-starter-stream-source-http/pom.xml
@@ -15,8 +15,12 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-http</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-java-dsl</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/spring-cloud-starter-stream-source-http/pom.xml
+++ b/spring-cloud-starter-stream-source-http/pom.xml
@@ -47,16 +47,6 @@
 					</generatedApps>
 				</configuration>
 			</plugin>
-			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<classpathDependencyExcludes>
-						<classpathDependencyExclude>org.springframework.security:spring-security-config</classpathDependencyExclude>
-						<classpathDependencyExclude>org.springframework.security:spring-security-core</classpathDependencyExclude>
-						<classpathDependencyExclude>org.springframework.security:spring-security-web</classpathDependencyExclude>
-					</classpathDependencyExcludes>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceProperties.java
+++ b/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceProperties.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.http.source;
+
+import org.hibernate.validator.constraints.NotEmpty;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.integration.http.support.DefaultHttpHeaderMapper;
+
+/**
+ * @author Artem Bilan
+ *
+ */
+@ConfigurationProperties("http")
+public class HttpSourceProperties {
+
+	/**
+	 * HTTP endpoint path mapping.
+	 */
+	private String pathPattern = "/";
+
+	/**
+	 * Headers that will be mapped.
+	 */
+	private String[] mappedRequestHeaders = { DefaultHttpHeaderMapper.HTTP_REQUEST_HEADER_NAME_PATTERN };
+
+	@NotEmpty
+	public String getPathPattern() {
+		return pathPattern;
+	}
+
+	public void setPathPattern(String pathPattern) {
+		this.pathPattern = pathPattern;
+	}
+
+	public String[] getMappedRequestHeaders() {
+		return mappedRequestHeaders;
+	}
+
+	public void setMappedRequestHeaders(String[] mappedRequestHeaders) {
+		this.mappedRequestHeaders = mappedRequestHeaders;
+	}
+
+}

--- a/spring-cloud-starter-stream-source-http/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
+++ b/spring-cloud-starter-stream-source-http/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
@@ -1,1 +1,2 @@
-configuration-properties.names=server.port,http.path-pattern
+configuration-properties.classes=org.springframework.cloud.stream.app.http.source.HttpSourceProperties
+configuration-properties.names=server.port


### PR DESCRIPTION
Fixes spring-cloud-stream-app-starters/http#3
      spring-cloud-stream-app-starters/http#1

Since we can't use `@ConfigurationProperties` with the `@RequestMapping`, plus right now there is no way to pass inbound headers,
rework the source to use Spring Integration HTTP Inbound Channel Adapter