### PR TITLE
GH-5: Make security for HTTP Source optional

### DIFF
--- a/spring-cloud-starter-stream-source-http/README.adoc
+++ b/spring-cloud-starter-stream-source-http/README.adoc
@@ -12,6 +12,7 @@ The **$$http$$** $$source$$ supports the following configuration properties:
 //tag::configuration-properties[]
 $$http.mapped-request-headers$$:: $$Headers that will be mapped.$$ *($$String[]$$, default: `$$<none>$$`)*
 $$http.path-pattern$$:: $$An Ant-Style pattern to determine which http requests will be captured.$$ *($$String$$, default: `$$/$$`)*
+$$http.secured$$:: $$Secure or not HTTP source path.$$ *($$boolean$$, default: `$$false$$`)*
 $$server.port$$:: $$Server HTTP port.$$ *($$Integer$$, default: `$$<none>$$`)*
 //end::configuration-properties[]
 

--- a/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceConfiguration.java
@@ -17,10 +17,12 @@
 package org.springframework.cloud.stream.app.http.source;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.integration.dsl.http.BaseHttpInboundEndpointSpec;
@@ -30,6 +32,7 @@ import org.springframework.integration.dsl.support.Consumer;
 import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.http.inbound.HttpRequestHandlingEndpointSupport;
 import org.springframework.integration.http.support.DefaultHttpHeaderMapper;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
 /**
  * A source module that listens for HTTP requests and emits the body as a message payload.
@@ -83,6 +86,13 @@ public class HttpSourceConfiguration {
 
 				})
 				.requestChannel(this.channels.output());
+	}
+
+	@Configuration
+	@ConditionalOnProperty(prefix = "http", name = "secured", havingValue = "false", matchIfMissing = true)
+	@EnableWebSecurity
+	protected static class DisableSecurityConfiguration {
+
 	}
 
 }

--- a/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceProperties.java
+++ b/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceProperties.java
@@ -38,6 +38,11 @@ public class HttpSourceProperties {
 	 */
 	private String[] mappedRequestHeaders = { DefaultHttpHeaderMapper.HTTP_REQUEST_HEADER_NAME_PATTERN };
 
+	/**
+	 * Secure or not HTTP source path.
+	 */
+	private boolean secured;
+
 	@NotEmpty
 	public String getPathPattern() {
 		return pathPattern;
@@ -53,6 +58,14 @@ public class HttpSourceProperties {
 
 	public void setMappedRequestHeaders(String[] mappedRequestHeaders) {
 		this.mappedRequestHeaders = mappedRequestHeaders;
+	}
+
+	public boolean isSecured() {
+		return this.secured;
+	}
+
+	public void setSecured(boolean secured) {
+		this.secured = secured;
 	}
 
 }


### PR DESCRIPTION
Fixes spring-cloud-stream-app-starters/http#5

* Add `http.secured` property with `false` by default
* Add internal `DisableSecurityConfiguration` with the
`@EnableWebSecurity` which is switched on when ``http.secured == false`
* Add appropriate secured and non-secured tests for HTTP Source
endpoint, as well as for `/health` and `/env`
* Tested as
`java -jar http-source-rabbit-1.2.0.BUILD-SNAPSHOT.jar --http.pathPattern=/data --http.secured=true`
via CURL when
```
management.context-path=/management
security.basic.path=/management/**
```
are removed from the `application.properties`