### PR TITLE
GH-8: More cleaner security disabling

### DIFF
--- a/spring-cloud-starter-stream-source-http/README.adoc
+++ b/spring-cloud-starter-stream-source-http/README.adoc
@@ -12,9 +12,11 @@ The **$$http$$** $$source$$ supports the following configuration properties:
 //tag::configuration-properties[]
 $$http.mapped-request-headers$$:: $$Headers that will be mapped.$$ *($$String[]$$, default: `$$<none>$$`)*
 $$http.path-pattern$$:: $$An Ant-Style pattern to determine which http requests will be captured.$$ *($$String$$, default: `$$/$$`)*
-$$http.secured$$:: $$Secure or not HTTP source path.$$ *($$Boolean$$, default: `$$false$$`)*
 $$server.port$$:: $$Server HTTP port.$$ *($$Integer$$, default: `$$<none>$$`)*
 //end::configuration-properties[]
+
+NOTE: The security is disabled for this application by default.
+To enable it you should use standard Spring Boot `security.basic.enabled = true` property.
 
 //end::ref-doc[]
 == Build

--- a/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceConfiguration.java
@@ -94,8 +94,14 @@ public class HttpSourceConfiguration {
 				.requestChannel(this.channels.output());
 	}
 
+	/**
+	 * The custom {@link WebSecurityConfigurerAdapter} to disable security in the application.
+	 * Since by default the security is enabled in Spring Boot, the condition for this configuration
+	 * is {@code matchIfMissing == true} to disable security by default.
+	 * @see org.springframework.boot.autoconfigure.security.SpringBootWebSecurityConfiguration.ApplicationNoWebSecurityConfigurerAdapter
+	 */
 	@Configuration
-	@ConditionalOnProperty(prefix = "http", name = "secured", havingValue = "false", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = "security.basic", name = "enabled", havingValue = "false", matchIfMissing = true)
 	@EnableWebSecurity
 	protected static class DisableSecurityConfiguration extends WebSecurityConfigurerAdapter {
 

--- a/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.app.http.source;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -31,7 +33,10 @@ import org.springframework.integration.dsl.http.HttpRequestHandlerEndpointSpec;
 import org.springframework.integration.dsl.support.Consumer;
 import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.http.inbound.HttpRequestHandlingEndpointSupport;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
 /**
  * A source module that listens for HTTP requests and emits the body as a message payload.
@@ -92,7 +97,19 @@ public class HttpSourceConfiguration {
 	@Configuration
 	@ConditionalOnProperty(prefix = "http", name = "secured", havingValue = "false", matchIfMissing = true)
 	@EnableWebSecurity
-	protected static class DisableSecurityConfiguration {
+	protected static class DisableSecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http.requestMatcher(new RequestMatcher() {
+
+				@Override
+				public boolean matches(HttpServletRequest request) {
+					return false;
+				}
+
+			});
+		}
 
 	}
 

--- a/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceProperties.java
+++ b/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceProperties.java
@@ -40,11 +40,6 @@ public class HttpSourceProperties {
 	 */
 	private String[] mappedRequestHeaders = { DefaultHttpHeaderMapper.HTTP_REQUEST_HEADER_NAME_PATTERN };
 
-	/**
-	 * Secure or not HTTP source path.
-	 */
-	private boolean secured;
-
 	@NotEmpty
 	public String getPathPattern() {
 		return pathPattern;
@@ -60,14 +55,6 @@ public class HttpSourceProperties {
 
 	public void setMappedRequestHeaders(String[] mappedRequestHeaders) {
 		this.mappedRequestHeaders = mappedRequestHeaders;
-	}
-
-	public boolean isSecured() {
-		return this.secured;
-	}
-
-	public void setSecured(boolean secured) {
-		this.secured = secured;
 	}
 
 }

--- a/spring-cloud-starter-stream-source-http/src/test/java/org/springframework/cloud/stream/app/http/source/HttpSourceTests.java
+++ b/spring-cloud-starter-stream-source-http/src/test/java/org/springframework/cloud/stream/app/http/source/HttpSourceTests.java
@@ -196,7 +196,7 @@ public abstract class HttpSourceTests {
 	}
 
 
-	@TestPropertySource(properties = {"http.mappedRequestHeaders = *", "http.secured = true"})
+	@TestPropertySource(properties = {"http.mappedRequestHeaders = *", "security.basic.enabled = true"})
 	public static class SecuredTests extends HttpSourceTests {
 
 		@Autowired

--- a/spring-cloud-starter-stream-source-http/src/test/java/org/springframework/cloud/stream/app/http/source/HttpSourceTests.java
+++ b/spring-cloud-starter-stream-source-http/src/test/java/org/springframework/cloud/stream/app/http/source/HttpSourceTests.java
@@ -83,7 +83,7 @@ public abstract class HttpSourceTests {
 	}
 
 	@TestPropertySource(properties = "http.pathPattern=/foo")
-	public static class SimpleMappingTests extends HttpSourceTests {
+	public static class NonSecuredTests extends HttpSourceTests {
 
 		@Test
 		public void testText() {
@@ -153,8 +153,51 @@ public abstract class HttpSourceTests {
 
 	}
 
+
+	@TestPropertySource(properties = "management.security.enabled=false")
+	public static class NonSecuredManagementDisabledTests extends HttpSourceTests {
+
+		@Test
+		public void testText() {
+			ResponseEntity<?> entity = restTemplate.postForEntity("http://localhost:" + port, "hello", Object.class);
+			assertEquals(HttpStatus.ACCEPTED, entity.getStatusCode());
+			assertThat(messageCollector.forChannel(channels.output()), receivesPayloadThat(is("hello")));
+		}
+
+		@Test
+		@SuppressWarnings("rawtypes")
+		public void testHealthEndpoint() throws Exception {
+			ResponseEntity<Map> response = this.restTemplate.getForEntity("http://localhost:" + port + "/health", Map.class);
+			assertEquals(HttpStatus.OK, response.getStatusCode());
+			assertTrue(response.hasBody());
+
+			Map health = response.getBody();
+
+			assertEquals("UP", health.get("status"));
+			assertTrue(health.containsKey("diskSpace"));
+		}
+
+		@Test
+		@SuppressWarnings("rawtypes")
+		public void testEnvEndpoint() throws Exception {
+			ResponseEntity<Map> response = this.restTemplate.getForEntity("http://localhost:" + port + "/env", Map.class);
+			assertEquals(HttpStatus.OK, response.getStatusCode());
+			assertTrue(response.hasBody());
+
+			Map env = response.getBody();
+
+			assertTrue(env.containsKey("server.ports"));
+
+			Map ports = (Map) env.get("server.ports");
+
+			assertEquals(this.port, ports.get("local.server.port"));
+		}
+
+	}
+
+
 	@TestPropertySource(properties = {"http.mappedRequestHeaders = *", "http.secured = true"})
-	public static class DefaultMappingTests extends HttpSourceTests {
+	public static class SecuredTests extends HttpSourceTests {
 
 		@Autowired
 		private SecurityProperties securityProperties;


### PR DESCRIPTION
Resolves spring-cloud-stream-app-starters/http#8

Since security disabling is really based on the present of custom
`WebSecurityConfigurerAdapter` add such an implementation to the
`DisableSecurityConfiguration` internal `@Configuration` enabled
by the `http.secured = false`.

The root of cause that Spring Boot's `ManagementWebSecurityAutoConfiguration`
doesn't register its custom `ApplicationNoWebSecurityConfigurerAdapter`
when we specify `management.security.enabled=false`.
Meanwhile all other `WebSecurityConfigurerAdapter` s aren't reachable because
of `@ConditionalOnMissingBean(WebSecurityConfiguration.class)` on the
`SpringBootWebSecurityConfiguration`