### PR TITLE
UnsatisfiedDependencyException during startup

### DIFF
--- a/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceConfiguration.java
@@ -17,13 +17,13 @@
 package org.springframework.cloud.stream.app.http.source;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.integration.expression.ValueExpression;
@@ -43,6 +43,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
  * @author Marius Bogoevici
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Christian Tzolov
  */
 @EnableBinding(Source.class)
 @EnableConfigurationProperties(HttpSourceProperties.class)
@@ -79,6 +80,15 @@ public class HttpSourceConfiguration {
 								.allowedHeaders(this.properties.getCors().getAllowedHeaders())
 								.allowCredentials(this.properties.getCors().getAllowCredentials()))
 				.requestChannel(this.channels.output());
+	}
+
+	/**
+	 * Re-include the SecurityAutoConfiguration to ensure that HttpSourceSecurityConfiguration works even in case when
+	 * the SecurityAutoConfiguration is excluded.
+	 */
+	@Configuration
+	@Import(SecurityAutoConfiguration.class)
+	protected static class IncludeSecurityAutoConfiguration {
 	}
 
 	/**

--- a/spring-cloud-starter-stream-source-http/src/test/java/org/springframework/cloud/stream/app/http/source/HttpSourceTests.java
+++ b/spring-cloud-starter-stream-source-http/src/test/java/org/springframework/cloud/stream/app/http/source/HttpSourceTests.java
@@ -16,15 +16,6 @@
 
 package org.springframework.cloud.stream.app.http.source;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.springframework.cloud.stream.test.matcher.MessageQueueMatcher.receivesPayloadThat;
-import static org.springframework.integration.test.matcher.HeaderMatcher.hasHeader;
-import static org.springframework.integration.test.matcher.PayloadMatcher.hasPayload;
-
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -52,6 +43,15 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.cloud.stream.test.matcher.MessageQueueMatcher.receivesPayloadThat;
+import static org.springframework.integration.test.matcher.HeaderMatcher.hasHeader;
+import static org.springframework.integration.test.matcher.PayloadMatcher.hasPayload;
+
 /**
  * Tests for HttpSourceConfiguration.
  *
@@ -60,9 +60,12 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @author Marius Bogoevici
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Christian Tzolov
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+		"spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration" })
 public abstract class HttpSourceTests {
 
 	@Autowired


### PR DESCRIPTION
  - Re-import the SecurityAutoConfiguration to ensure that required by HttpSourceSecurityConfiguration beans are presented even if the SecurityAutoConfiguration is excluded.
  - Exclude the SecurityAutoConfiguration for all test to emulate the current apps mode.

Resolves #20