### PR TITLE
Use core/app-starters-security-common for security management

### DIFF
--- a/http-app-dependencies/pom.xml
+++ b/http-app-dependencies/pom.xml
@@ -29,6 +29,11 @@
 				<version>4.5.3</version>
 				<scope>test</scope>
 			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud.stream.app</groupId>
+				<artifactId>app-starters-security-common</artifactId>
+				<version>2.1.0.BUILD-SNAPSHOT</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/http-app-dependencies/pom.xml
+++ b/http-app-dependencies/pom.xml
@@ -33,6 +33,7 @@
 				<groupId>org.springframework.cloud.stream.app</groupId>
 				<artifactId>app-starters-security-common</artifactId>
 				<version>2.1.0.BUILD-SNAPSHOT</version>
+				<scope>test</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/http-app-dependencies/pom.xml
+++ b/http-app-dependencies/pom.xml
@@ -33,7 +33,6 @@
 				<groupId>org.springframework.cloud.stream.app</groupId>
 				<artifactId>app-starters-security-common</artifactId>
 				<version>2.1.0.BUILD-SNAPSHOT</version>
-				<scope>test</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/http-app-dependencies/pom.xml
+++ b/http-app-dependencies/pom.xml
@@ -23,12 +23,6 @@
 				<artifactId>spring-cloud-starter-stream-source-http</artifactId>
 				<version>2.1.0.BUILD-SNAPSHOT</version>
 			</dependency>
-			<dependency>
-				<groupId>org.apache.httpcomponents</groupId>
-				<artifactId>httpclient</artifactId>
-				<version>4.5.3</version>
-				<scope>test</scope>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/http-app-dependencies/pom.xml
+++ b/http-app-dependencies/pom.xml
@@ -29,11 +29,6 @@
 				<version>4.5.3</version>
 				<scope>test</scope>
 			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud.stream.app</groupId>
-				<artifactId>app-starters-security-common</artifactId>
-				<version>2.1.0.BUILD-SNAPSHOT</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/spring-cloud-starter-stream-source-http/README.adoc
+++ b/spring-cloud-starter-stream-source-http/README.adoc
@@ -33,11 +33,11 @@ The **$$http$$** $$source$$ supports the following configuration properties:
 $$http.cors.allow-credentials$$:: $$Whether the browser should include any cookies associated with the domain of the request being annotated.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$http.cors.allowed-headers$$:: $$List of request headers that can be used during the actual request.$$ *($$String[]$$, default: `$$<none>$$`)*
 $$http.cors.allowed-origins$$:: $$List of allowed origins, e.g. "http://domain1.com".$$ *($$String[]$$, default: `$$<none>$$`)*
-$$http.enable-csrf$$:: $$The security CSRF enabling flag. Makes sense only if 'enableSecurity = true'.$$ *($$Boolean$$, default: `$$false$$`)*
-$$http.enable-security$$:: $$The security enabling flag.$$ *($$Boolean$$, default: `$$false$$`)*
 $$http.mapped-request-headers$$:: $$Headers that will be mapped.$$ *($$String[]$$, default: `$$<none>$$`)*
 $$http.path-pattern$$:: $$An Ant-Style pattern to determine which http requests will be captured.$$ *($$String$$, default: `$$/$$`)*
 $$server.port$$:: $$Server HTTP port.$$ *($$Integer$$, default: `$$8080$$`)*
+$$spring.cloud.stream.security.csrf-enabled$$:: $$The security CSRF enabling flag. Makes sense only if security 'enabled` is `true'.$$ *($$Boolean$$, default: `$$true$$`)*
+$$spring.cloud.stream.security.enabled$$:: $$The security enabling flag.$$ *($$Boolean$$, default: `$$false$$`)*
 //end::configuration-properties[]
 
 NOTE: Security is disabled for this application by default.

--- a/spring-cloud-starter-stream-source-http/README.adoc
+++ b/spring-cloud-starter-stream-source-http/README.adoc
@@ -36,8 +36,6 @@ $$http.cors.allowed-origins$$:: $$List of allowed origins, e.g. "http://domain1.
 $$http.mapped-request-headers$$:: $$Headers that will be mapped.$$ *($$String[]$$, default: `$$<none>$$`)*
 $$http.path-pattern$$:: $$An Ant-Style pattern to determine which http requests will be captured.$$ *($$String$$, default: `$$/$$`)*
 $$server.port$$:: $$Server HTTP port.$$ *($$Integer$$, default: `$$8080$$`)*
-$$spring.cloud.stream.security.csrf-enabled$$:: $$The security CSRF enabling flag. Makes sense only if security 'enabled` is `true'.$$ *($$Boolean$$, default: `$$true$$`)*
-$$spring.cloud.stream.security.enabled$$:: $$The security enabling flag.$$ *($$Boolean$$, default: `$$false$$`)*
 //end::configuration-properties[]
 
 NOTE: Security is disabled for this application by default.

--- a/spring-cloud-starter-stream-source-http/pom.xml
+++ b/spring-cloud-starter-stream-source-http/pom.xml
@@ -18,7 +18,10 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-http</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.cloud.stream.app</groupId>
+			<artifactId>app-starters-security-common</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>

--- a/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceConfiguration.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.stream.app.http.source;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.annotation.EnableBinding;
-import org.springframework.cloud.stream.app.security.common.SecurityCommonAutoConfigurationProperties;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpMethod;

--- a/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceConfiguration.java
@@ -42,7 +42,7 @@ import org.springframework.integration.http.inbound.HttpRequestHandlingEndpointS
  * @author Christian Tzolov
  */
 @EnableBinding(Source.class)
-@EnableConfigurationProperties({ HttpSourceProperties.class, SecurityCommonAutoConfigurationProperties.class })
+@EnableConfigurationProperties({ HttpSourceProperties.class})
 public class HttpSourceConfiguration {
 
 	@Autowired

--- a/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceProperties.java
+++ b/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceProperties.java
@@ -42,16 +42,6 @@ public class HttpSourceProperties {
 	private String[] mappedRequestHeaders = { DefaultHttpHeaderMapper.HTTP_REQUEST_HEADER_NAME_PATTERN };
 
 	/**
-	 * The security enabling flag.
-	 */
-	private boolean enableSecurity;
-
-	/**
-	 * The security CSRF enabling flag. Makes sense only if 'enableSecurity = true'.
-	 */
-	private boolean enableCsrf;
-
-	/**
 	 * CORS properties.
 	 */
 	@NestedConfigurationProperty
@@ -72,22 +62,6 @@ public class HttpSourceProperties {
 
 	public void setMappedRequestHeaders(String[] mappedRequestHeaders) {
 		this.mappedRequestHeaders = mappedRequestHeaders;
-	}
-
-	public boolean isEnableSecurity() {
-		return this.enableSecurity;
-	}
-
-	public void setEnableSecurity(boolean enableSecurity) {
-		this.enableSecurity = enableSecurity;
-	}
-
-	public boolean isEnableCsrf() {
-		return this.enableCsrf;
-	}
-
-	public void setEnableCsrf(boolean enableCsrf) {
-		this.enableCsrf = enableCsrf;
 	}
 
 	public HttpSourceCorsProperties getCors() {

--- a/spring-cloud-starter-stream-source-http/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
+++ b/spring-cloud-starter-stream-source-http/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
@@ -1,3 +1,4 @@
 configuration-properties.classes=org.springframework.cloud.stream.app.http.source.HttpSourceProperties, \
-  org.springframework.cloud.stream.app.http.source.HttpSourceCorsProperties
+  org.springframework.cloud.stream.app.http.source.HttpSourceCorsProperties, \
+  org.springframework.cloud.stream.app.security.common.SecurityCommonAutoConfigurationProperties
 configuration-properties.names=server.port

--- a/spring-cloud-starter-stream-source-http/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
+++ b/spring-cloud-starter-stream-source-http/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
@@ -1,4 +1,3 @@
 configuration-properties.classes=org.springframework.cloud.stream.app.http.source.HttpSourceProperties, \
-  org.springframework.cloud.stream.app.http.source.HttpSourceCorsProperties, \
-  org.springframework.cloud.stream.app.security.common.SecurityCommonAutoConfigurationProperties
+  org.springframework.cloud.stream.app.http.source.HttpSourceCorsProperties
 configuration-properties.names=server.port

--- a/spring-cloud-starter-stream-source-http/src/main/resources/config/application.yml
+++ b/spring-cloud-starter-stream-source-http/src/main/resources/config/application.yml
@@ -1,5 +1,5 @@
 spring:
   cloud:
-    stream:
+    app-starter-stream:
       security:
         enabled: false

--- a/spring-cloud-starter-stream-source-http/src/main/resources/config/application.yml
+++ b/spring-cloud-starter-stream-source-http/src/main/resources/config/application.yml
@@ -1,0 +1,5 @@
+spring:
+  cloud:
+    stream:
+      security:
+        enabled: false

--- a/spring-cloud-starter-stream-source-http/src/main/resources/config/application.yml
+++ b/spring-cloud-starter-stream-source-http/src/main/resources/config/application.yml
@@ -1,5 +1,5 @@
 spring:
   cloud:
-    app-starter-stream:
+    stream-app-starters:
       security:
         enabled: false

--- a/spring-cloud-starter-stream-source-http/src/main/resources/config/application.yml
+++ b/spring-cloud-starter-stream-source-http/src/main/resources/config/application.yml
@@ -1,5 +1,5 @@
 spring:
   cloud:
-    stream-app-starters:
+    streamapp:
       security:
         enabled: false

--- a/spring-cloud-starter-stream-source-http/src/test/java/org/springframework/cloud/stream/app/http/source/HttpSourceTests.java
+++ b/spring-cloud-starter-stream-source-http/src/test/java/org/springframework/cloud/stream/app/http/source/HttpSourceTests.java
@@ -179,8 +179,8 @@ public abstract class HttpSourceTests {
 
 	@TestPropertySource(properties = {
 			"http.mappedRequestHeaders = *",
-			"spring.cloud.stream-app-starters.security.enabled = true",
-			"spring.cloud.stream-app-starters.security.csrf-enabled=false",
+			"spring.cloud.streamapp.security.enabled = true",
+			"spring.cloud.streamapp.security.csrf-enabled=false",
 			"http.cors.allowedOrigins = /bar"
 	})
 	public static class SecuredTests extends HttpSourceTests {
@@ -235,8 +235,8 @@ public abstract class HttpSourceTests {
 
 	@TestPropertySource(properties = {
 			"http.mappedRequestHeaders = *",
-			"spring.cloud.stream-app-starters.security.enabled = true",
-			"spring.cloud.stream-app-starters.security.csrf-enabled=true"
+			"spring.cloud.streamapp.security.enabled = true",
+			"spring.cloud.streamapp.security.csrf-enabled=true"
 	})
 	public static class CsrfEnabledTests extends HttpSourceTests {
 

--- a/spring-cloud-starter-stream-source-http/src/test/java/org/springframework/cloud/stream/app/http/source/HttpSourceTests.java
+++ b/spring-cloud-starter-stream-source-http/src/test/java/org/springframework/cloud/stream/app/http/source/HttpSourceTests.java
@@ -179,8 +179,8 @@ public abstract class HttpSourceTests {
 
 	@TestPropertySource(properties = {
 			"http.mappedRequestHeaders = *",
-			"spring.cloud.app-starter-stream.security.enabled = true",
-			"spring.cloud.app-starter-stream.security.csrf-enabled=false",
+			"spring.cloud.stream-app-starters.security.enabled = true",
+			"spring.cloud.stream-app-starters.security.csrf-enabled=false",
 			"http.cors.allowedOrigins = /bar"
 	})
 	public static class SecuredTests extends HttpSourceTests {
@@ -235,8 +235,8 @@ public abstract class HttpSourceTests {
 
 	@TestPropertySource(properties = {
 			"http.mappedRequestHeaders = *",
-			"spring.cloud.app-starter-stream.security.enabled = true",
-			"spring.cloud.app-starter-stream.security.csrf-enabled=true"
+			"spring.cloud.stream-app-starters.security.enabled = true",
+			"spring.cloud.stream-app-starters.security.csrf-enabled=true"
 	})
 	public static class CsrfEnabledTests extends HttpSourceTests {
 

--- a/spring-cloud-starter-stream-source-http/src/test/java/org/springframework/cloud/stream/app/http/source/HttpSourceTests.java
+++ b/spring-cloud-starter-stream-source-http/src/test/java/org/springframework/cloud/stream/app/http/source/HttpSourceTests.java
@@ -179,8 +179,8 @@ public abstract class HttpSourceTests {
 
 	@TestPropertySource(properties = {
 			"http.mappedRequestHeaders = *",
-			"spring.cloud.stream.security.enabled = true",
-			"spring.cloud.stream.security.csrf-enabled=false",
+			"spring.cloud.app-starter-stream.security.enabled = true",
+			"spring.cloud.app-starter-stream.security.csrf-enabled=false",
 			"http.cors.allowedOrigins = /bar"
 	})
 	public static class SecuredTests extends HttpSourceTests {
@@ -235,8 +235,8 @@ public abstract class HttpSourceTests {
 
 	@TestPropertySource(properties = {
 			"http.mappedRequestHeaders = *",
-			"spring.cloud.stream.security.enabled = true",
-			"spring.cloud.stream.security.csrf-enabled=true"
+			"spring.cloud.app-starter-stream.security.enabled = true",
+			"spring.cloud.app-starter-stream.security.csrf-enabled=true"
 	})
 	public static class CsrfEnabledTests extends HttpSourceTests {
 

--- a/spring-cloud-starter-stream-source-http/src/test/java/org/springframework/cloud/stream/app/http/source/HttpSourceTests.java
+++ b/spring-cloud-starter-stream-source-http/src/test/java/org/springframework/cloud/stream/app/http/source/HttpSourceTests.java
@@ -76,8 +76,7 @@ public abstract class HttpSourceTests {
 	protected TestRestTemplate restTemplate;
 
 	@TestPropertySource(properties = {
-			"http.pathPattern = /foo",
-			"spring.cloud.stream.security.enabled=false" })
+			"http.pathPattern = /foo"})
 	public static class NonSecuredTests extends HttpSourceTests {
 
 		@Test


### PR DESCRIPTION
 - Add core/app-starters-security-common dependency.
 - Remove the internal security management in favor of using the core/app-starters-security-common module.
 - Replace local enableSecurity and enableCsrf properties by and spring.cloud.stream.security.enabled and spring.cloud.stream.security.csrf-enabled from SecurityCommonAutoConfigurationProperties (inside core/app-starters-security-common).
 - Adjust existing tests with the new properties.

Resolves #24

Part of https://github.com/spring-cloud-stream-app-starters/app-starters-release/issues/161
Related to https://github.com/spring-cloud/spring-cloud-app-starters-maven-plugins/issues/36