### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/spring-cloud-starter-stream-source-http/README.adoc
+++ b/spring-cloud-starter-stream-source-http/README.adoc
@@ -32,7 +32,7 @@ The **$$http$$** $$source$$ supports the following configuration properties:
 //tag::configuration-properties[]
 $$http.cors.allow-credentials$$:: $$Whether the browser should include any cookies associated with the domain of the request being annotated.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$http.cors.allowed-headers$$:: $$List of request headers that can be used during the actual request.$$ *($$String[]$$, default: `$$<none>$$`)*
-$$http.cors.allowed-origins$$:: $$List of allowed origins, e.g. "http://domain1.com".$$ *($$String[]$$, default: `$$<none>$$`)*
+$$http.cors.allowed-origins$$:: $$List of allowed origins, e.g. "https://domain1.com".$$ *($$String[]$$, default: `$$<none>$$`)*
 $$http.enable-csrf$$:: $$The security CSRF enabling flag. Makes sense only if 'enableSecurity = true'.$$ *($$Boolean$$, default: `$$false$$`)*
 $$http.enable-security$$:: $$The security enabling flag.$$ *($$Boolean$$, default: `$$false$$`)*
 $$http.mapped-request-headers$$:: $$Headers that will be mapped.$$ *($$String[]$$, default: `$$<none>$$`)*

--- a/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceCorsProperties.java
+++ b/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceCorsProperties.java
@@ -32,7 +32,7 @@ import org.springframework.web.cors.CorsConfiguration;
 public class HttpSourceCorsProperties {
 
 	/**
-	 * List of allowed origins, e.g. "http://domain1.com".
+	 * List of allowed origins, e.g. "https://domain1.com".
 	 */
 	private String[] allowedOrigins = { CorsConfiguration.ALL };
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://domain1.com (UnknownHostException) with 2 occurrences migrated to:  
  https://domain1.com ([https](https://domain1.com) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 14 occurrences